### PR TITLE
use different migration table

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/mutecomm/go-sqlcipher v0.0.0-20190227152316-55dbde17881f // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/status-im/migrate/v4 v4.3.1-status
+	github.com/status-im/migrate/v4 v4.0.0-20190821140204-a9d340ec8fb76af4afda06acf01740d45d2661ed
 	github.com/stretchr/testify v1.3.1-0.20190712000136-221dbe5ed467
 )

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
-github.com/status-im/migrate/v4 v4.3.1-status h1:tJwsEYLgbFkvlTSMk89APwRDfpr4yG8wcwPeudsqPwo=
-github.com/status-im/migrate/v4 v4.3.1-status/go.mod h1:r8HggRBZ/k7TRwByq/Hp3P/ubFppIna0nvyavVK0pjA=
+github.com/status-im/migrate/v4 v4.0.0-20190821140204-a9d340ec8fb76af4afda06acf01740d45d2661ed h1:K2iga8l8OQIHnk2bBq2QsZTO2Q38YWy04xIspdITCdM=
+github.com/status-im/migrate/v4 v4.0.0-20190821140204-a9d340ec8fb76af4afda06acf01740d45d2661ed/go.mod h1:r8HggRBZ/k7TRwByq/Hp3P/ubFppIna0nvyavVK0pjA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/persistenceutil/migrations.go
+++ b/persistenceutil/migrations.go
@@ -1,33 +1,70 @@
 package persistenceutil
 
 import (
+	"github.com/pkg/errors"
+	"strings"
+
 	nodemigrations "github.com/vacp2p/mvds/node/migrations"
 	peersmigrations "github.com/vacp2p/mvds/peers/migrations"
 	statemigrations "github.com/vacp2p/mvds/state/migrations"
 	storemigrations "github.com/vacp2p/mvds/store/migrations"
 )
 
+type getter func(string) ([]byte, error)
+
 type Migration struct {
 	Names  []string
 	Getter func(name string) ([]byte, error)
 }
 
+func prepareMigrations(migrations []Migration) ([]string, getter, error) {
+	var allNames []string
+	nameToGetter := make(map[string]getter)
+
+	for _, m := range migrations {
+		for _, name := range m.Names {
+			if !validateName(name) {
+				continue
+			}
+
+			if _, ok := nameToGetter[name]; ok {
+				return nil, nil, errors.Errorf("migration with name %s already exists", name)
+			}
+			allNames = append(allNames, name)
+			nameToGetter[name] = m.Getter
+		}
+	}
+
+	return allNames, func(name string) ([]byte, error) {
+		getter, ok := nameToGetter[name]
+		if !ok {
+			return nil, errors.Errorf("no migration for name %s", name)
+		}
+		return getter(name)
+	}, nil
+}
+
 // DefaultMigrations is a collection of all mvds components migrations.
-var DefaultMigrations = map[string]Migration{
-	"node": {
+var DefaultMigrations = []Migration{
+	{
 		Names:  nodemigrations.AssetNames(),
 		Getter: nodemigrations.Asset,
 	},
-	"peers": {
+	{
 		Names:  peersmigrations.AssetNames(),
 		Getter: peersmigrations.Asset,
 	},
-	"state": {
+	{
 		Names:  statemigrations.AssetNames(),
 		Getter: statemigrations.Asset,
 	},
-	"store": {
+	{
 		Names:  storemigrations.AssetNames(),
 		Getter: storemigrations.Asset,
 	},
+}
+
+// validateName verifies that only *.sql files are taken into consideration.
+func validateName(name string) bool {
+	return strings.HasSuffix(name, ".sql")
 }

--- a/persistenceutil/sqlite.go
+++ b/persistenceutil/sqlite.go
@@ -23,6 +23,16 @@ type MigrationConfig struct {
 	AssetGetter func(name string) ([]byte, error)
 }
 
+// Migrate migrates a provided sqldb
+func Migrate(db *sql.DB) error {
+	assetNames, assetGetter, err := prepareMigrations(DefaultMigrations)
+	if err != nil {
+		return err
+	}
+	return ApplyMigrations(db, assetNames, assetGetter)
+
+}
+
 // Open opens or initializes a new database for a given file path.
 // MigrationConfig is optional but if provided migrations are applied automatically.
 func Open(path, key string, mc ...MigrationConfig) (*sql.DB, error) {
@@ -90,7 +100,7 @@ func ApplyMigrations(db *sql.DB, assetNames []string, assetGetter func(name stri
 	}
 
 	driver, err := sqlcipher.WithInstance(db, &sqlcipher.Config{
-		// MigrationsTable: "mvds_" + sqlcipher.DefaultMigrationsTable,
+		MigrationsTable: "mvds_" + sqlcipher.DefaultMigrationsTable,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to create driver")

--- a/vendor/github.com/status-im/migrate/v4/database/sqlcipher/sqlcipher.go
+++ b/vendor/github.com/status-im/migrate/v4/database/sqlcipher/sqlcipher.go
@@ -63,7 +63,7 @@ func (m *Sqlite) ensureVersionTable() error {
 	query := fmt.Sprintf(`
 	CREATE TABLE IF NOT EXISTS %s (version uint64,dirty bool);
   CREATE UNIQUE INDEX IF NOT EXISTS version_unique ON %s (version);
-  `, DefaultMigrationsTable, DefaultMigrationsTable)
+  `, m.config.MigrationsTable, m.config.MigrationsTable)
 
 	if _, err := m.db.Exec(query); err != nil {
 		return err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -16,7 +16,7 @@ github.com/mutecomm/go-sqlcipher
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
-# github.com/status-im/migrate/v4 v4.3.1-status
+# github.com/status-im/migrate/v4 v4.0.0-20190821140204-a9d340ec8fb76af4afda06acf01740d45d2661ed
 github.com/status-im/migrate/v4
 github.com/status-im/migrate/v4/database/sqlcipher
 github.com/status-im/migrate/v4/source/go_bindata


### PR DESCRIPTION
Use latest migrate, and offers a `Migrate` method that client should be using (passing a sql.DB as an argument), to migrate data, so that migrations from mvds are stored in a separate table.