### PR TITLE
Don't retun error on removing state when receiving messages

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ var (
 	interactive   int
 )
 
-func init() {
+func parseFlags() {
 	flag.IntVar(&offline, "offline", 90, "percentage of time a node is offline")
 	flag.IntVar(&nodeCount, "nodes", 3, "amount of nodes")
 	flag.IntVar(&communicating, "communicating", 2, "amount of nodes sending messages")
@@ -37,6 +37,7 @@ func init() {
 
 func main() {
 
+	parseFlags()
 	// @todo validate flags
 
 	transports := make([]*transport.ChannelTransport, 0)

--- a/node/node.go
+++ b/node/node.go
@@ -492,7 +492,7 @@ func (n *Node) onMessage(sender state.PeerID, msg protobuf.Message) error {
 	)
 
 	err := n.syncState.Remove(id, sender)
-	if err != nil {
+	if err != nil && err != state.ErrStateNotFound {
 		return err
 	}
 


### PR DESCRIPTION
When receiving messages the state for the message is removed.
If no state is found an error was thrown.
This should not cause an error as that's an ok scenario.
Also changes the parsing of the flags from init to a custom method, as I
bumped in this issue https://github.com/golang/go/issues/31859