### PR TITLE
enhancement/remove-double-check

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -267,15 +267,6 @@ func (n *Node) RequestMessage(group state.GroupID, id state.MessageID) error {
 	}
 
 	for _, p := range peers {
-		exist, err := n.IsPeerInGroup(group, p)
-		if err != nil {
-			return err
-		}
-
-		if exist {
-			continue
-		}
-
 		n.insertSyncState(&group, id, p, state.REQUEST)
 	}
 


### PR DESCRIPTION
`GetByGroupID` should only return peers that are in the group, hence this check is redundant. This was an overflow of when we had the ability to not share with peers who are in a group, this currently is not the case therefore better to remove this check.