### PR TITLE
Set SendEpoch instead of cumulating it

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -728,6 +728,6 @@ func (n *Node) insertSyncState(groupID *state.GroupID, messageID state.MessageID
 
 func (n *Node) updateSendEpoch(s state.State) state.State {
 	s.SendCount += 1
-	s.SendEpoch += n.nextEpoch(s.SendCount, n.epoch)
+	s.SendEpoch = n.nextEpoch(s.SendCount, n.epoch)
 	return s
 }


### PR DESCRIPTION
`CalculateNextEpoch` should set `SendEpoch` instead of cumulating it.

This resulted in a bug where new accounts would actually use mvds for re-transmission, while as time passed and epoch grew, messages would stop being transmitted as it would just double and double the epoch. 